### PR TITLE
Bugged Horse?

### DIFF
--- a/Bugged Horse?
+++ b/Bugged Horse?
@@ -1,0 +1,4 @@
+Today 25/05/14 i traded a brown horse (tier 1) and 32 Emerald Blocks for a black horse (tier 2) it was on speed 3 and jump 3
+and the xp was 34 so i decided to try level it up but then i relised that no matter how far i travel/ride it it wouldnt even 
+get at least 1 more xp or level up...     
+~EternalPandae


### PR DESCRIPTION
Today 25/05/14 i traded a brown horse (tier 1) and 32 Emerald Blocks for a black horse (tier 2) it was on speed 3 and jump 3
 and the xp was 34 so i decided to try level it up but then i relised that no matter how far i travel/ride it it wouldnt even 
 get at least 1 more xp or level up...  
 ~EternalPandae
