### PR TITLE
Create Ghost Bug

### DIFF
--- a/Ghost Bug
+++ b/Ghost Bug
@@ -1,0 +1,3 @@
+I am having a bug where my game wont let me attack or be hit because the game ended when i was finishing a quest. What do i do?
+I was doing the bowl quest for yaha (spelled wrong) and when i gave him the bowl and the the server ended. It thinks that im 
+still talking to him so i cant do anything. Please help. I put a long time into this and i dont want to lose it.


### PR DESCRIPTION
I am having a bug where my game wont let me attack or be hit because the game ended when i was finishing a quest. What do i do?
I was doing the bowl quest for yaha (spelled wrong) and when i gave him the bowl and the the server ended. It thinks that im still talking to him so i cant do anything. Please help. I put a long time into this and i dont want to lose it.
