### PR TITLE
Create Trade Glitch

### DIFF
--- a/Trade Glitch
+++ b/Trade Glitch
@@ -1,0 +1,13 @@
+My Minecraft username is Jeffery_1919. I had recently traded a brown horse that was level 10/10. 
+I wanted to trade him for 30 emerald blocks as i also had a black horse. One guy (MrPiggy200) wanted to buy the brown orse so we traded.
+Anyway, he kept asking me to put it under his name and he kept cancelling the trade until i did. Not knowing what would happen,
+I put it under his name instead of mine. He cancelled the trade and the MY HORSE went into HIS inventory without him giving me anything.
+He switched worlds and i followed him with the /find command. I kept asking him for it back or to atleast pay for it but he kept
+saying he had no idea what i was talking about. I eventually gave up.
+It's thing like this that make me sick to my stomach and make me not want to play this game anymore because there are people out there
+that do this sort of thing. Please fix this so i can trade without worry. It's happened twice now and I'm getting tired and anoyed by it.
+If it continues i'm just gonna trust no one anymore and keep everything to myself (which is not the point of a multiplayer) or i'll just
+stop playing this game all together even though i enjoy it (at the age of 17). I appreciate your attention.
+
+Sincerely,
+Jeffery_1919


### PR DESCRIPTION
My Minecraft username is Jeffery_1919. I had recently traded a brown horse that was level 10/10. 
I wanted to trade him for 30 emerald blocks as i also had a black horse. One guy (MrPiggy200) wanted to buy the brown orse so we traded.
Anyway, he kept asking me to put it under his name and he kept cancelling the trade until i did. Not knowing what would happen,
I put it under his name instead of mine. He cancelled the trade and the MY HORSE went into HIS inventory without him giving me anything.
He switched worlds and i followed him with the /find command. I kept asking him for it back or to atleast pay for it but he kept
saying he had no idea what i was talking about. I eventually gave up.
It's thing like this that make me sick to my stomach and make me not want to play this game anymore because there are people out there
that do this sort of thing. Please fix this so i can trade without worry. It's happened twice now and I'm getting tired and anoyed by it.
If it continues i'm just gonna trust no one anymore and keep everything to myself (which is not the point of a multiplayer) or i'll just
stop playing this game all together even though i enjoy it (at the age of 17). I appreciate your attention.

Sincerely,
Jeffery_1919
